### PR TITLE
MI-9405 Smaller "give up" threshold on LogScale

### DIFF
--- a/ZedGraph/source/ZedGraph/DateScale.cs
+++ b/ZedGraph/source/ZedGraph/DateScale.cs
@@ -435,7 +435,7 @@ namespace ZedGraph
 			base.PickScale( pane, g, scaleFactor );
 
 			// Test for trivial condition of range = 0 and pick a suitable default
-			if ( _max - _min < 1.0e-20 )
+			if ( _max - _min < SmallestValue )
 			{
 				if ( _maxAuto )
 					_max = _max + 0.2 * ( _max == 0 ? 1.0 : Math.Abs( _max ) );

--- a/ZedGraph/source/ZedGraph/ExponentScale.cs
+++ b/ZedGraph/source/ZedGraph/ExponentScale.cs
@@ -253,7 +253,7 @@ namespace ZedGraph
 			base.PickScale( pane, g, scaleFactor );
 
 			// Test for trivial condition of range = 0 and pick a suitable default
-			if ( _max - _min < 1.0e-20 )
+			if ( _max - _min < SmallestValue )
 			{
 				if ( _maxAuto )
 					_max = _max + 0.2 * ( _max == 0 ? 1.0 : Math.Abs( _max ) );

--- a/ZedGraph/source/ZedGraph/LinearScale.cs
+++ b/ZedGraph/source/ZedGraph/LinearScale.cs
@@ -137,7 +137,7 @@ namespace ZedGraph
 			base.PickScale( pane, g, scaleFactor );
 
 			// Test for trivial condition of range = 0 and pick a suitable default
-			if ( _max - _min < 1.0e-30 )
+			if ( _max - _min < SmallestValue )
 			{
 				if ( _maxAuto )
 					_max = _max + 0.2 * ( _max == 0 ? 1.0 : Math.Abs( _max ) );

--- a/ZedGraph/source/ZedGraph/LogScale.cs
+++ b/ZedGraph/source/ZedGraph/LogScale.cs
@@ -336,11 +336,6 @@ namespace ZedGraph
 
             if(_minAuto && _maxAuto)
             {
-                //iStart = (int) ( Math.Ceiling( SafeLog( this.min ) - 1.0e-12 ) );
-                //iEnd = (int) ( Math.Floor( SafeLog( this.max ) + 1.0e-12 ) );
-
-                //nTics = (int)( ( Math.Floor( Scale.SafeLog( _max ) + 1.0e-12 ) ) -
-                //		( Math.Ceiling( Scale.SafeLog( _min ) - 1.0e-12 ) ) + 1 ) / CyclesPerStep;
                 nTics = (int)( ( SafeLog( _max ) - SafeLog( _min ) ) / CyclesPerStep ) + 1;
             }
             else
@@ -515,7 +510,7 @@ namespace ZedGraph
 			//this.numDec = 0;		// The number of decimal places to display is not used
 
 			// Test for trivial condition of range = 0 and pick a suitable default
-			if ( _max - _min < 1.0e-20 )
+			if ( _max - _min < SmallestValue )
 			{
 				if ( _maxAuto )
 					_max = _max * 2.0;

--- a/ZedGraph/source/ZedGraph/Scale.cs
+++ b/ZedGraph/source/ZedGraph/Scale.cs
@@ -44,6 +44,8 @@ namespace ZedGraph
 	[Serializable]
 	abstract public class Scale : ISerializable
 	{
+        protected const double SmallestValue = 1.0e-30;
+
 	#region Fields
 
 		/// <summary> Private fields for the <see cref="Axis"/> scale definitions.
@@ -2558,9 +2560,9 @@ namespace ZedGraph
 				double mag = -100;
 				double mag2 = -100;
 
-				if ( Math.Abs( _min ) > 1.0e-30 )
+				if ( Math.Abs( _min ) > SmallestValue )
 					mag = Math.Floor( Math.Log10( Math.Abs( _min ) ) );
-				if ( Math.Abs( _max ) > 1.0e-30 )
+				if ( Math.Abs( _max ) > SmallestValue )
 					mag2 = Math.Floor( Math.Log10( Math.Abs( _max ) ) );
 
 				mag = Math.Max( mag2, mag );
@@ -2927,7 +2929,7 @@ namespace ZedGraph
 		/// argument was negative or zero</returns>
 		public static double SafeLog( double x )
 		{
-			if ( x > 1.0e-20 )
+			if ( x > SmallestValue )
 				return Math.Log10( x );
 			else
 				return 0.0;
@@ -2940,7 +2942,7 @@ namespace ZedGraph
 		/// <param name="exponent">The exponent value to use for calculating the exponential.</param>
 		public static double SafeExp( double x, double exponent )
 		{
-			if ( x > 1.0e-20 )
+			if ( x > SmallestValue )
 				return Math.Pow( x, exponent );
 			else
 				return 0.0;


### PR DESCRIPTION
Introduce a constant for consistent minimum value on log scale. In some places, the code previously used 10^-20 and others used 10^-30. I've now consistently used the latter value.
